### PR TITLE
OffscreenContext Proposal

### DIFF
--- a/bldsys/cmake/sample_helper.cmake
+++ b/bldsys/cmake/sample_helper.cmake
@@ -157,11 +157,20 @@ endfunction()
 function(add_sample_with_tags)
     set(options)
     set(oneValueArgs ID CATEGORY AUTHOR NAME DESCRIPTION)
-    set(multiValueArgs TAGS)
+    set(multiValueArgs TAGS FILES)
 
     cmake_parse_arguments(TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     list(APPEND TARGET_TAGS "any")
+
+    set(SRC_FILES
+        ${TARGET_ID}.h
+        ${TARGET_ID}.cpp
+    )
+
+    if (TARGET_FILES)
+        list(APPEND SRC_FILES ${TARGET_FILES})
+    endif()
 
     add_project(
         TYPE "Sample"
@@ -173,8 +182,7 @@ function(add_sample_with_tags)
         TAGS 
             ${TARGET_TAGS}
         FILES
-            ${TARGET_ID}.h
-            ${TARGET_ID}.cpp)
+            ${SRC_FILES})
 
 endfunction()
 

--- a/samples/extensions/open_gl_interop/CMakeLists.txt
+++ b/samples/extensions/open_gl_interop/CMakeLists.txt
@@ -35,7 +35,10 @@ add_sample_with_tags(
     NAME "OpenGL Interoperability"
     DESCRIPTION "Example showing sharing resources between OpenGL and Vulkan"
     TAGS
-        "opengl")
+        "opengl"
+    FILES
+        offscreen_context.h
+        offscreen_context.cpp)
 
 if (USE_GLFW)
     target_compile_definitions(open_gl_interop PUBLIC USE_GLFW)

--- a/samples/extensions/open_gl_interop/offscreen_context.cpp
+++ b/samples/extensions/open_gl_interop/offscreen_context.cpp
@@ -1,0 +1,152 @@
+
+#include "offscreen_context.h"
+
+#include <string>
+#include <vector>
+
+#include "common/logging.h"
+
+void APIENTRY debug_message_callback(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const void *user_param)
+{
+	switch (severity)
+	{
+		case GL_DEBUG_SEVERITY_HIGH:
+			LOGE("OpenGL: {}", message);
+			break;
+		case GL_DEBUG_SEVERITY_MEDIUM:
+			LOGW("OpenGL: {}", message);
+			break;
+		case GL_DEBUG_SEVERITY_LOW:
+			LOGI("OpenGL: {}", message);
+			break;
+		default:
+		case GL_DEBUG_SEVERITY_NOTIFICATION:
+			LOGD("OpenGL: {}", message);
+	}
+}
+
+OffscreenContext::OffscreenContext()
+{
+	init_context();
+
+	glDebugMessageCallback(debug_message_callback, NULL);
+	glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+}
+
+OffscreenContext::~OffscreenContext()
+{
+	destroy_context();
+}
+
+GLuint OffscreenContext::load_shader(const char *shader_source, GLenum shader_type)
+{
+	std::string source     = get_shader_header() + "\n" + std::string(shader_source);
+	const char *source_ptr = source.c_str();
+	const GLint size       = static_cast<GLint>(source.size());
+
+	GLuint shader = glCreateShader(shader_type);
+	glShaderSource(shader, 1, &source_ptr, &size);
+	glCompileShader(shader);
+
+	GLint is_compiled = 0;
+	glGetShaderiv(shader, GL_COMPILE_STATUS, &is_compiled);
+	if (is_compiled == GL_FALSE)
+	{
+		GLint max_length = 0;
+		glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &max_length);
+
+		// The maxLength includes the NULL character
+		std::vector<GLchar> error_log(max_length);
+		glGetShaderInfoLog(shader, max_length, &max_length, &error_log[0]);
+		std::string str_error;
+		str_error.insert(str_error.end(), error_log.begin(), error_log.end());
+
+		// Provide the infolog in whatever manor you deem best.
+		// Exit with failure.
+		glDeleteShader(shader);        // Don't leak the shader.
+		LOGE("OpenGL: Shader compilation failed", str_error.c_str());
+	}
+	return shader;
+}
+
+GLuint OffscreenContext::build_program(const char *vertex_shader_source, const char *fragment_shader_source)
+{
+	GLuint program = glCreateProgram();
+	GLuint vs      = load_shader(vertex_shader_source, GL_VERTEX_SHADER);
+	GLuint fs      = load_shader(fragment_shader_source, GL_FRAGMENT_SHADER);
+	glAttachShader(program, vs);
+	glAttachShader(program, fs);
+	glLinkProgram(program);
+	glDeleteShader(vs);
+	glDeleteShader(fs);
+	return program;
+}
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+void OffscreenContext::init_context()
+{
+	EGLint egl_maj_vers{0},
+	    egl_min_vers{0};
+	data.display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+	eglInitialize(data.display, &egl_maj_vers, &egl_min_vers);
+
+	constexpr EGLint conf_attr[] = {
+	    EGL_RENDERABLE_TYPE, EGL_OPENGL_ES3_BIT_KHR,
+	    EGL_NONE};
+
+	EGLint num_configs;
+	eglChooseConfig(data.display, conf_attr, &data.config, 1, &num_configs);
+
+	// Create a EGL context
+	constexpr EGLint ctx_attr[] = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE};
+
+	data.context = eglCreateContext(data.display, data.config, EGL_NO_CONTEXT, ctx_attr);
+	if (data.context == EGL_NO_CONTEXT)
+	{
+		throw std::runtime_error{"Failed to create EGL context"};
+	}
+
+	// Create an offscreen pbuffer surface, and then make it current
+	constexpr EGLint surface_attr[] = {EGL_WIDTH, 10, EGL_HEIGHT, 10, EGL_NONE};
+	data.surface                    = eglCreatePbufferSurface(data.display, data.config, surface_attr);
+	eglMakeCurrent(data.display, data.surface, data.surface, data.context);
+	gladLoadGLES2Loader((GLADloadproc) &eglGetProcAddress);
+
+	LOGD("EGL init with version {}.{}", egl_maj_vers, egl_min_vers);
+}
+
+void OffscreenContext::destroy_context()
+{
+	eglDestroySurface(data.display, data.surface);
+	eglDestroyContext(data.display, data.context);
+}
+
+std::string OffscreenContext::get_shader_header()
+{
+	return "#version 320 es";
+}
+#else
+void OffscreenContext::init_context()
+{
+	glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+	glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, 1);
+	glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+	data.window = glfwCreateWindow(SHARED_TEXTURE_DIMENSION, SHARED_TEXTURE_DIMENSION, "OpenGL Window", nullptr, nullptr);
+	glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+	glfwMakeContextCurrent(data.window);
+	gladLoadGL();
+}
+
+void OffscreenContext::destroy_context()
+{
+	glfwDestroyWindow(data.window);
+}
+
+std::string OffscreenContext::get_shader_header()
+{
+	return "#version 450 core";
+}
+#endif

--- a/samples/extensions/open_gl_interop/offscreen_context.h
+++ b/samples/extensions/open_gl_interop/offscreen_context.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <memory>
+
+#include <glad/glad.h>
+
+#include "common/vk_common.h"
+
+constexpr uint32_t SHARED_TEXTURE_DIMENSION = 512;
+
+#ifdef WIN32
+constexpr const char *HOST_MEMORY_EXTENSION_NAME    = VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME;
+constexpr const char *HOST_SEMAPHORE_EXTENSION_NAME = VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME;
+#	define glImportSemaphore glImportSemaphoreWin32HandleEXT
+#	define glImportMemory glImportMemoryWin32HandleEXT
+#	define GL_HANDLE_TYPE GL_HANDLE_TYPE_OPAQUE_WIN32_EXT
+#	define VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT
+#	define VK_EXTERNAL_MEMORY_HANDLE_TYPE VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT
+#else
+constexpr const char *HOST_MEMORY_EXTENSION_NAME    = VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME;
+constexpr const char *HOST_SEMAPHORE_EXTENSION_NAME = VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME;
+#	define glImportSemaphore glImportSemaphoreFdEXT
+#	define glImportMemory glImportMemoryFdEXT
+#	define GL_HANDLE_TYPE GL_HANDLE_TYPE_OPAQUE_FD_EXT
+#	define VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT
+#	define VK_EXTERNAL_MEMORY_HANDLE_TYPE VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT
+#endif
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+// Android
+#	include <EGL/egl.h>
+#	include <EGL/eglext.h>
+
+struct ContextData
+{
+	EGLConfig  config{nullptr};
+	EGLSurface surface{EGL_NO_SURFACE};
+	EGLContext context{EGL_NO_CONTEXT};
+	EGLDisplay display{EGL_NO_DISPLAY};
+};
+#else
+// Desktop
+#	include <GLFW/glfw3.h>
+#	include <GLFW/glfw3native.h>
+
+struct ContextData
+{
+	GLFWwindow *window;
+};
+#endif
+
+class OffscreenContext
+{
+  public:
+	OffscreenContext();
+
+	~OffscreenContext();
+
+	// Shared
+	GLuint build_program(const char *vertex_shader_source, const char *fragment_shader_source);
+
+  private:
+	// Platform specific
+	void init_context();
+
+	void destroy_context();
+
+	std::string get_shader_header();
+
+	ContextData data;
+
+	GLuint load_shader(const char *shader_source, GLenum shader_type);
+};

--- a/samples/extensions/open_gl_interop/open_gl_interop.h
+++ b/samples/extensions/open_gl_interop/open_gl_interop.h
@@ -20,6 +20,7 @@
 #include "api_vulkan_sample.h"
 #include "rendering/render_pipeline.h"
 #include "scene_graph/components/camera.h"
+#include "timer.h"
 
 #if defined(USE_GLFW)
 
@@ -40,10 +41,11 @@ struct VertexStructure
 	float normal[3];
 };
 
+class OffscreenContext;
+struct GLData;
+
 class OpenGLInterop : public ApiVulkanSample
 {
-	friend class OpenGLWindow;
-
   public:
 	OpenGLInterop();
 	~OpenGLInterop();
@@ -57,7 +59,6 @@ class OpenGLInterop : public ApiVulkanSample
 
   private:
 	void prepare_shared_resources();
-	void prepare_opengl_context();
 	void generate_quad();
 	void setup_descriptor_pool();
 	void setup_descriptor_set_layout();
@@ -67,13 +68,15 @@ class OpenGLInterop : public ApiVulkanSample
 	void update_uniform_buffers();
 	void draw();
 
-	std::unique_ptr<OpenGLWindow> glWindow;
+	vkb::Timer        timer;
+	OffscreenContext *gl_context{nullptr};
+	GLData *          gl_data{nullptr};
 
 	struct ShareHandles
 	{
 		Handle memory{INVALID_HANDLE_VALUE};
-		Handle glReady{INVALID_HANDLE_VALUE};
-		Handle glComplete{INVALID_HANDLE_VALUE};
+		Handle gl_ready{INVALID_HANDLE_VALUE};
+		Handle gl_complete{INVALID_HANDLE_VALUE};
 	} shareHandles;
 
 	struct SharedTexture
@@ -88,8 +91,8 @@ class OpenGLInterop : public ApiVulkanSample
 
 	struct Semaphores
 	{
-		VkSemaphore glReady{VK_NULL_HANDLE};
-		VkSemaphore glComplete{VK_NULL_HANDLE};
+		VkSemaphore gl_ready{VK_NULL_HANDLE};
+		VkSemaphore gl_complete{VK_NULL_HANDLE};
 	} sharedSemaphores;
 
 	std::unique_ptr<vkb::core::Buffer> vertex_buffer;


### PR DESCRIPTION
In the original PR the friend class has made the tutorial aspect of the sample a little confusing as you must navigate too and from the friend class and the sample class. The original purpose of the friend class was to hide the GL specific functions so that it is not shared with the entire framework.

In this proposal I have moved the less important GL methods into OffscreenContext with device specific create/destroy_context methods. This is used within the sample with forward referencing. The addition of OffscreenContext provides a place to define non-essential GL specific methods without bloating the tutorial. It is not the tutorials goal to show how a shader is loaded or how to create a context on a specific device.

This proposal is not set in stone just a solution i have found for this particular issue.