### PR TITLE
Link test framework with test targets

### DIFF
--- a/bldsys/cmake/sample_helper.cmake
+++ b/bldsys/cmake/sample_helper.cmake
@@ -265,6 +265,7 @@ function(add_project)
     if(${TARGET_TYPE} STREQUAL "Test")
         target_compile_definitions(${PROJECT_NAME} PUBLIC $<TARGET_PROPERTY:test_framework,COMPILE_DEFINITIONS>)
         target_include_directories(${PROJECT_NAME} PUBLIC $<TARGET_PROPERTY:test_framework,INCLUDE_DIRECTORIES>)
+        target_link_libraries(${PROJECT_NAME} PRIVATE test_framework)
     endif()
 
     # capitalise the first letter of the category  (performance -> Performance) 

--- a/samples/extensions/open_gl_interop/CMakeLists.txt
+++ b/samples/extensions/open_gl_interop/CMakeLists.txt
@@ -1,4 +1,5 @@
-# Copyright (c) 2019-2020, Bradley Austin Davis
+# Copyright (c) 2020, Bradley Austin Davis
+# Copyright (c) 2020, Arm Limited
 #
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/samples/extensions/open_gl_interop/offscreen_context.cpp
+++ b/samples/extensions/open_gl_interop/offscreen_context.cpp
@@ -1,5 +1,6 @@
-/* Copyright (c) 2019-2020, Bradley Austin Davis & Tom Atkinson
- *
+/* Copyright (c) 2020, Arm Limited
+ * Copyright (c) 2020, Bradley Austin Davis
+ * 
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 the "License";

--- a/samples/extensions/open_gl_interop/offscreen_context.h
+++ b/samples/extensions/open_gl_interop/offscreen_context.h
@@ -1,4 +1,5 @@
-/* Copyright (c) 2019-2020, Bradley Austin Davis & Tom Atkinson
+/* Copyright (c) 2020, Arm Limited
+ * Copyright (c) 2020, Bradley Austin Davis
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/samples/extensions/open_gl_interop/open_gl_interop.cpp
+++ b/samples/extensions/open_gl_interop/open_gl_interop.cpp
@@ -1,4 +1,5 @@
-/* Copyright (c) 2019-2020, Bradley Austin Davis
+/* Copyright (c) 2020, Bradley Austin Davis
+ * Copyright (c) 2020, Arm Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  *

--- a/samples/extensions/open_gl_interop/open_gl_interop.h
+++ b/samples/extensions/open_gl_interop/open_gl_interop.h
@@ -1,4 +1,5 @@
-/* Copyright (c) 2019-2020, Bradley Austin Davis
+/* Copyright (c) 2020, Bradley Austin Davis
+ * Copyright (c) 2020, Arm Limited
  *
  * SPDX-License-Identifier: Apache-2.0
  *


### PR DESCRIPTION
Linking the test framework fixes the linux build in the CI. Tested locally using the khronosgroup/vulkan-samples:latest docker image